### PR TITLE
get_ancestors() keyword argument

### DIFF
--- a/ontoma/ols.py
+++ b/ontoma/ols.py
@@ -155,7 +155,7 @@ class OlsClient:
         """Gets the data for a given term
 
         Args:
-            ontology:   The name of the ontology
+            ont:        The name of the ontology
             iri:        The IRI of a term
         """
         url = self.ontology_ancestors.format(ontology=ont,

--- a/ontoma/ols.py
+++ b/ontoma/ols.py
@@ -151,14 +151,14 @@ class OlsClient:
         return response.json()
 
 
-    def get_ancestors(self, ont, iri):
+    def get_ancestors(self, ontology, iri):
         """Gets the data for a given term
 
         Args:
-            ont:        The name of the ontology
+            ontology:   The name of the ontology
             iri:        The IRI of a term
         """
-        url = self.ontology_ancestors.format(ontology=ont,
+        url = self.ontology_ancestors.format(ontology=ontology,
                                              iri=_dparse(iri))
         response = self.session.get(url)
         try:


### PR DESCRIPTION
Align keyword argument name for `get_ancestors()` with docs: `ontology` => `ont`

Ideally, it would be great to rename the argument to `ontology` so it's consistent with `get_term()`.