### PR TITLE
[Il ontologies support]

### DIFF
--- a/ontoma/interface.py
+++ b/ontoma/interface.py
@@ -115,7 +115,10 @@ def make_uri(ontology_short_form):
     elif (ontology_code.startswith('HP') or
           ontology_code.startswith('MP') or
           ontology_code.startswith('MONDO') or
-          ontology_code.startswith('UBERON')):
+          ontology_code.startswith('UBERON') or
+          ontology_code.startswith('GO') or
+          ontology_code.startswith('NCIT') or
+          ontology_code.startswith('DOID')):
         return 'http://purl.obolibrary.org/obo/' + ontology_code
     elif ontology_code.startswith('Orphanet'):
         return 'http://www.orpha.net/ORDO/' + ontology_code

--- a/ontoma/interface.py
+++ b/ontoma/interface.py
@@ -80,7 +80,8 @@ def xref_to_name_and_label_mapping(obonetwork):
 def make_uri(ontology_short_form):
     '''
     Transform a short form ontology code in a full URI.
-    Currently works for EFO, HPO, ORDO and MP.
+    Currently works for EFO, HPO, MONDO, UBERON, ORDO
+    GO, NCIT, DOID, and MP.
 
     Args:
         ontology_short_form: An ontology code in the short format, like 'EFO:0000270'.


### PR DESCRIPTION
This PR closes [#1307](https://github.com/opentargets/platform/issues/1307), where OnToma was crashing due to not being able to generate the URI from the resulting mapping because the ontology was not supported in the `make_uri` method.

I've added support for GO, DOID, and NCIT matches, all of them covered by OBO PURLs.

Right now building the URI is not necessary for the platform, but as `make_uri` is mentioned throughout the whole module, I have preferred to tweak the function rather than removing it and break something.
