### PR TITLE
build: fix dependencies versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ setup(
     ],
     keywords='opentargets ontology efo mapper',
     install_requires=[
-        'click',
-        'pandas',
-        'pronto',
-        'requests',
-        'retry2',
+        'click==8.1.7',
+        'pandas==2.2.2',
+        'pronto==2.5.3',
+        'requests==2.32.0',
+        'retry2==0.9.5',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
We need to lock the versions of the Ontoma dependencies to make sure that the module runs as expected.

## Background

There is a problem with `pronto`s version that is not able to load the EFO slim OWLs. I've tried with versions 3.64 to 3.68, returning the same error: `ValueError: undeclared synonym type: http://purl.obolibrary.org/obo/mondo#ABBREVIATION`

This is not a problem when we run the evidence source parsers because the pronto version is fixed to `2.53.3`. However, if you pip install ontoma outside of this environment, pronto 2.7 will be installed and then the loading of the slim file will fail.

This PR addresses the problem so that ontoma works out of the box.