### PR TITLE
fix: suppressing pronto warnings

### DIFF
--- a/ontoma/efo_handler.py
+++ b/ontoma/efo_handler.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import urllib.request
+import warnings
 
 import pandas as pd
 import pronto
@@ -13,6 +14,11 @@ from typing import Dict
 from ontoma import ontology
 
 logger = logging.getLogger()
+
+# Suppressing the SyntaxWarning from pronto:
+warnings.filterwarnings(
+    "ignore", category=pronto.warnings.SyntaxWarning, module="pronto"
+)
 
 
 class EFOHandler:


### PR DESCRIPTION
A simple update on how Ontoma uses pronto to interact with ontologies. So far upon initialising the ontologies, a bunch of warnings are thrown at users, but this PR removes these harmless messages.