### PR TITLE
fix(disease curation): filter out entity labels that contain only numbers

### DIFF
--- a/src/ontoma/datasource/disease_curation.py
+++ b/src/ontoma/datasource/disease_curation.py
@@ -85,6 +85,7 @@ class DiseaseCuration:
                     how="inner"
                 )
                 # cleanup
+                .filter(~f.col("entityLabel").rlike('^[12]\)$')) # specifically to remove "1)" and "2)"
                 .filter((f.col("entityId").isNotNull()) & (f.length("entityId") > 0))
                 .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
                 .distinct()


### PR DESCRIPTION
This fix addresses a specific case where entity labels contain only numbers after being processed by the [clean_disease_label](https://github.com/opentargets/OnToma/blob/vh-new-ontoma/src/ontoma/common/utils.py#L100) function.

Before:
```
+-------------------------------------------------+------------------------------------+
|PROPERTY_VALUE                                   |SEMANTIC_TAG                        |
+-------------------------------------------------+------------------------------------+
|Duration to complete alphanumeric path (trail #2)|http://www.ebi.ac.uk/efo/EFO_0008354|
|Duration to complete numeric path (trail #1)     |http://www.ebi.ac.uk/efo/EFO_0008354|
+-------------------------------------------------+------------------------------------+
```

After:
```
+-----------+-----------+
|   entityId|entityLabel|
+-----------+-----------+
|EFO_0008354|         2)|
|EFO_0008354|         1)|
+-----------+-----------+
```

These labels are subsequently normalised to `1` and `2`, which leads to incorrect mappings. 

These labels are only expected from Open Targets disease curation (and they aren't particularly exciting disease labels), so it is easier to filter these labels out than to change the `clean_disease_label` function to process these correctly.