### PR TITLE
fix: make path check URI friendly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontoma"
-version = "2.1.0"
+version = "2.1.1"
 description = "Ontology mapping for Open Targets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ontoma/ontoma.py
+++ b/src/ontoma/ontoma.py
@@ -66,18 +66,6 @@ class OnToma:
         except Exception:
             cache_exists = False
 
-        # raise error if both entity_lut_list and a valid cache_dir are not provided
-        if not self.entity_lut_list and not cache_exists:
-            raise ValueError("At least one of 'entity_lut_list' or a valid 'cache_dir' must be provided.")
-
-        # if entity_lut_list is provided, validate the input
-        if self.entity_lut_list:
-            if not isinstance(self.entity_lut_list, list):
-                raise TypeError("entity_lut_list must be a list.")
-            
-            if not all(isinstance(entity_lut, RawEntityLUT) for entity_lut in self.entity_lut_list):
-                raise TypeError("Each entity_lut must be a RawEntityLUT.")
-
         # if cache exists, load the entity lookup table    
         if cache_exists:
             self._entity_lut = ReadyEntityLUT(
@@ -86,8 +74,14 @@ class OnToma:
             )
             logger.info(f"Loaded entity lookup table from {self.cache_dir}.")
         
-        # cache does not exist, so generate the entity lookup table
-        else:
+        # if entity_lut_list is provided, validate the input then generate the entity lookup table
+        elif self.entity_lut_list:
+            if not isinstance(self.entity_lut_list, list):
+                raise TypeError("entity_lut_list must be a list.")
+            
+            if not all(isinstance(entity_lut, RawEntityLUT) for entity_lut in self.entity_lut_list):
+                raise TypeError("Each entity_lut must be a RawEntityLUT.")
+
             logger.info(f"Generating entity lookup table.")
             self._entity_lut = self._generate_entity_lut(self.entity_lut_list)
 
@@ -99,6 +93,9 @@ class OnToma:
             # cache_dir is not provided, so suggest specifying a cache_directory
             else:
                 logger.warning(f"Cache directory is not specified. Specify a cache directory to speed up subsequent OnToma usage.")
+        # raise error if neither entity_lut_list nor a valid cache_dir were provided
+        else:
+            raise ValueError("At least one of 'entity_lut_list' or a valid 'cache_dir' must be provided.")
 
     @property
     def df(self: OnToma) -> DataFrame:

--- a/src/ontoma/ontoma.py
+++ b/src/ontoma/ontoma.py
@@ -59,8 +59,15 @@ class OnToma:
         ):
             raise ValueError("Spark session is missing configuration required for Spark NLP.")
         
+        # if spark can read cache_dir, set cache_exists to True, otherwise False
+        try:
+            self.spark.read.parquet(self.cache_dir)
+            cache_exists = True
+        except:
+            cache_exists = False
+
         # raise error if both entity_lut_list and a valid cache_dir are not provided
-        if not self.entity_lut_list and (not self.cache_dir or not os.path.isdir(self.cache_dir)):
+        if not self.entity_lut_list and (not self.cache_dir or not cache_exists):
             raise ValueError("At least one of 'entity_lut_list' or a valid 'cache_dir' must be provided.")
         
         # if entity_lut_list is provided, validate the input
@@ -72,7 +79,7 @@ class OnToma:
                 raise TypeError("Each entity_lut must be a RawEntityLUT.")
 
         # if cache_dir is provided and it exists, load the entity lookup table
-        if self.cache_dir and os.path.exists(self.cache_dir):
+        if self.cache_dir and cache_exists:
             self._entity_lut = ReadyEntityLUT(
                 _df=self.spark.read.parquet(self.cache_dir),
                 _schema=ReadyEntityLUT.get_schema()

--- a/uv.lock
+++ b/uv.lock
@@ -480,7 +480,7 @@ wheels = [
 
 [[package]]
 name = "ontoma"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },


### PR DESCRIPTION
Current implementation in OnToma works locally, but fails when paths are Google Cloud Storage URIs.

This PR fixes that by using spark to perform the check instead of using the os library.

The logic in the `post_init` has also been simplified to be clearer.