### PR TITLE
feat(ner): extend ner api to extract diseases/indications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontoma"
-version = "2.1.0"
+version = "2.2.0"
 description = "Ontology mapping for Open Targets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontoma"
-version = "2.2.0"
+version = "2.3.0"
 description = "Ontology mapping for Open Targets"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/ontoma/datasource/drug.py
+++ b/src/ontoma/datasource/drug.py
@@ -17,17 +17,17 @@ if TYPE_CHECKING:
 
 
 class OpenTargetsDrug:
-    """Class to extract drug entities from the Open Targets drug index."""
+    """Class to extract drug entities from a dataset following the Open Targets drug index schema."""
 
     @classmethod
     def as_label_lut(
         cls: type[OpenTargetsDrug], 
         drug_index: DataFrame
     ) -> RawEntityLUT:
-        """Generate drug label lookup table from the Open Targets drug index.
+        """Generate drug label lookup table from a dataset following the Open Targets drug index schema.
         
         Args:
-            drug_index (DataFrame): Open Targets drug index.
+            drug_index (DataFrame): Dataset following the Open Targets drug index schema.
 
         Returns:
             RawEntityLUT: Drug label lookup table.
@@ -35,6 +35,12 @@ class OpenTargetsDrug:
         return RawEntityLUT(
             _df=(
                 drug_index
+                # early filter: only process drugs with meaningful label information
+                .filter(
+                    (~f.lower(f.col("name")).startswith("chembl"))
+                    | (f.size(f.col("tradeNames")) > 0)
+                    | (f.size(f.col("synonyms")) > 0)
+                )
                 # filter crossReferences for sources that have labels
                 .withColumn(
                     "crossReferences", 

--- a/src/ontoma/ner/README.md
+++ b/src/ontoma/ner/README.md
@@ -6,14 +6,20 @@ Named Entity Recognition (NER) preprocessing for OnToma entity mapping.
 
 The NER module extracts clean entity names from raw text labels **before** mapping them to ontology IDs. This is useful when your input data contains:
 
+### Drug Labels
 - Dosages: "0.001% atropine" → "atropine"
 - Drug forms: "aspirin tablets" → "aspirin"
 - Combinations: "abacavir + lamivudine" → ["abacavir", "lamivudine"]
 - Brand names: "Actemra" → "actemra"
 
+### Disease Labels
+- Clinical descriptions: "metastatic melanoma treatment" → "melanoma"
+- Multiple conditions: "type 2 diabetes and hypertension" → ["diabetes", "hypertension"]
+- Medical terminology: "acute myocardial infarction" → "myocardial infarction"
+
 ## Usage
 
-### Basic Example
+### Drug Entity Extraction
 
 ```python
 from pyspark.sql import SparkSession
@@ -47,12 +53,51 @@ mapped_df = ont.map_entities(
     result_col_name="drug_ids",
     entity_col_name="clean_drug_name",
     entity_kind="label",
-    type_col=f.lit("drug")
+    type_col=f.lit("CD")
+)
+```
+
+### Disease Entity Extraction
+
+```python
+from pyspark.sql import SparkSession
+from ontoma import OnToma, OpenTargetsDisease
+from ontoma.ner.disease import extract_disease_entities
+import pyspark.sql.functions as f
+
+# Step 1: Extract clean disease entities from raw labels
+df_extracted = extract_disease_entities(
+    spark=spark,
+    df=raw_disease_df,
+    input_col="raw_indication_label",
+    output_col="extracted_diseases"
+)
+
+# Result: raw_indication_label="metastatic melanoma treatment" → extracted_diseases=["melanoma"]
+
+# Step 2: Explode arrays for mapping
+df_exploded = df_extracted.select(
+    "*", 
+    f.explode("extracted_diseases").alias("clean_disease_name")
+)
+
+# Step 3: Map to disease IDs using OnToma
+disease_index = spark.read.parquet("path/to/disease/index")
+disease_lut = OpenTargetsDisease.as_label_lut(disease_index)
+ont = OnToma(spark=spark, entity_lut_list=[disease_lut])
+
+mapped_df = ont.map_entities(
+    df=df_exploded,
+    result_col_name="disease_ids",
+    entity_col_name="clean_disease_name",
+    entity_kind="label",
+    type_col=f.lit("DS")
 )
 ```
 
 ### Options
 
+#### Drug Extraction
 ```python
 extract_drug_entities(
     spark=spark,
@@ -67,11 +112,21 @@ extract_drug_entities(
 )
 ```
 
+#### Disease Extraction
+```python
+extract_disease_entities(
+    spark=spark,
+    df=df,
+    input_col="raw_indication",
+    output_col="extracted_diseases"
+)
+```
+
 ## Architecture
 
-### Tiered Extraction Strategy
+### Drug Extraction: Tiered Strategy
 
-The module uses a **lazy tiered approach** for efficiency:
+The drug module uses a **lazy tiered approach** for efficiency:
 
 1. **Regex (optional)**: Pattern matching for biologics with common suffixes
    - `-mab` (monoclonal antibodies): rituximab, trastuzumab
@@ -88,41 +143,66 @@ The module uses a **lazy tiered approach** for efficiency:
    - Clinical terminology
    - Broader coverage but less precise
 
+### Disease Extraction: Single Model Strategy
+
+The disease module uses a **simplified single-model approach**:
+
+1. **BioBERT Disease Model**: Direct entity extraction
+   - Clinical descriptions and medical terminology
+   - Multiple conditions in single text
+   - Fast processing without batching complexity
+
 
 ## Models
 
-### BioBERT (`alvaroalon2/biobert_chemical_ner`)
+### Drug Models
+
+#### BioBERT (`alvaroalon2/biobert_chemical_ner`)
 - **Training**: BC5CDR chemical entity dataset
 - **Strengths**: Small molecules, precise boundaries, salt forms
 - **Weaknesses**: Misses some brand names and biologics
 - **Size**: ~430MB
 
-### DrugTEMIST (`BSC-NLP4BIA/bsc-bio-ehr-es-carmen-drugtemist`)
+#### DrugTEMIST (`BSC-NLP4BIA/bsc-bio-ehr-es-carmen-drugtemist`)
 - **Training**: Clinical EHR data (Spanish + English)
 - **Strengths**: Brand names, clinical terminology, biologics
 - **Weaknesses**: Less precise boundaries, sometimes over-extracts
 - **Size**: ~500MB
 
+### Disease Models
+
+#### BioBERT Disease (`alvaroalon2/biobert_diseases_ner`)
+- **Training**: BC5CDR-diseases and NCBI-diseases corpus
+- **Strengths**: Medical terminology, clinical descriptions
+- **Weaknesses**: May miss rare disease names
+- **Size**: ~430MB
+
 ## Performance
 
 For Apple Silicon (M1/M2/M3), PyTorch will automatically use MPS acceleration.
 
-### Apple M1 Pro
+### Drug Extraction
+#### Apple M1 Pro
 - **175k drug labels**: ~10-15 minutes
 - **Batch size**: 128-256 (optimal)
 - **Acceleration**: MPS (Metal Performance Shaders)
 
-### CPU-only
+#### CPU-only
 - **175k drug labels**: ~60 minutes
 - **Batch size**: 32-64 (optimal)
 
-### GPU (CUDA)
-- **175k drug labels**: ~20 minutes
-- **Batch size**: 128-512 (optimal)
+### Disease Extraction
+#### Apple M1 Pro
+- **1k disease labels**: 25 seconds
+- **No batching required**: Streamlined processing
+- **Acceleration**: MPS (Metal Performance Shaders)
+
+#### CPU-only
+- **1k disease labels**: ~35 seconds
+- **No batching required**: Streamlined processing
 
 ## Entity Types
 
 - ✅ **Drugs** (small molecules, biologics, brand names)
-Coming soon:
-- 🚧 **Diseases** (planned)
+- ✅ **Diseases** (clinical descriptions, medical terminology)
 

--- a/src/ontoma/ner/disease.py
+++ b/src/ontoma/ner/disease.py
@@ -1,0 +1,96 @@
+"""Disease entity extraction using NER for OnToma preprocessing."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ontoma.ner._pipelines import create_ner_pipeline
+
+if TYPE_CHECKING:
+    from pyspark.sql import DataFrame, SparkSession
+
+logger = logging.getLogger(__name__)
+
+BIOBERT_LABELS = ['DISEASE']
+
+def extract_disease_entities(
+    spark: SparkSession,
+    df: DataFrame,
+    input_col: str,
+    output_col: str = "extracted_diseases",
+) -> DataFrame:
+    """Extract disease entities from raw indication labels using NER.
+    
+    This is a preprocessing step for OnToma mapping. Use this when your
+    input text contains indications that need to be extracted and cleaned
+    before mapping to disease IDs.
+    
+    Args:
+        spark: Active Spark session
+        df: Spark DataFrame with drug labels
+        input_col: Column containing raw drug labels
+        output_col: Column name for extracted entities (array of strings)
+        
+    Returns:
+        Spark DataFrame with extracted entities column
+
+    Note:
+        - First run will download models (~430MB)
+        - Processing converts Spark DF → Pandas → NER → Spark DF
+        - On Apple Silicon, uses MPS acceleration automatically
+    """
+    if input_col not in df.columns:
+        raise ValueError(f"Column '{input_col}' not found in DataFrame")
+    
+    logger.info("load biobert model...")
+    biobert_pipeline = create_biobert_disease_ner()
+    
+    logger.info("convert spark dataframe to pandas for ner processing...")
+    pdf = df.toPandas()
+    texts = pdf[input_col].fillna("").tolist()
+    
+    all_results = []
+    for text in texts:
+        if not text or text.strip() == "":
+            all_results.append([])
+            continue
+        
+        results = set()
+        
+        try:
+            entities = biobert_pipeline(text)
+            for ent in entities:
+                entity_label = ent.get('entity_group', '').upper()
+                if any(label in entity_label for label in ['DISEASE']):
+                    word = ent['word'].strip()
+                    if len(word) > 1 and not word.isdigit():
+                        results.add(word.lower())
+        except Exception as e:
+            print(f"ner failed for '{text}': {e}")
+        
+        all_results.append(sorted(list(results)))
+    
+    pdf[output_col] = all_results
+    
+    logger.info("convert results back to Spark DataFrame...")
+    result_df = spark.createDataFrame(pdf)
+    
+    logger.info("drug entity extraction complete.")
+    
+    return result_df
+
+
+def create_biobert_disease_ner():
+    """Create BioBERT NER pipeline for disease extraction.
+
+    BioBERT model fine-tuned in NER task with BC5CDR-diseases and NCBI-diseases corpus
+
+    Returns:
+        Transformers NER pipeline for BioBERT
+    """
+    return create_ner_pipeline(
+        model_name="alvaroalon2/biobert_diseases_ner",
+        tokenizer_name="alvaroalon2/biobert_diseases_ner",
+        aggregation_strategy="max"
+    )

--- a/tests/test_ner_disease_extraction.py
+++ b/tests/test_ner_disease_extraction.py
@@ -1,0 +1,108 @@
+"""Tests for disease entity extraction using NER."""
+
+import pytest
+
+from ontoma.ner import disease as disease_module
+
+
+@pytest.mark.slow
+def test_extract_disease_entities_basic(spark, monkeypatch):
+    """Ensure disease extraction produces cleaned lower-case entities."""
+    test_data = [
+        ("Metastatic melanoma treatment", ["melanoma"]),
+        ("Type 2 diabetes and resistant hypertension", ["diabetes", "hypertension"]),
+        ("unknown condition", []),
+    ]
+
+    # Mock the pipeline with simple function returning expected entities
+    def mock_pipeline(text):
+        responses = {
+            "Metastatic melanoma treatment": [
+                {"entity_group": "DISEASE", "word": "Melanoma"},
+            ],
+            "Type 2 diabetes and resistant hypertension": [
+                {"entity_group": "DISEASE", "word": "Diabetes"},
+                {"entity_group": "gene", "word": "TP53"},
+                {"entity_group": "DISEASE", "word": "hypertension"},
+            ],
+            "unknown condition": [],
+        }
+        return responses.get(text, [])
+
+    monkeypatch.setattr(disease_module, "create_biobert_disease_ner", lambda: mock_pipeline)
+
+    df = spark.createDataFrame([(text,) for text, _ in test_data], ["raw_indication"])
+
+    result_df = disease_module.extract_disease_entities(
+        spark=spark,
+        df=df,
+        input_col="raw_indication",
+        output_col="disease_entities",
+    )
+
+    result_pdf = result_df.toPandas()
+    for i, (raw_text, expected_entities) in enumerate(test_data):
+        actual_entities = result_pdf.iloc[i]["disease_entities"]
+        assert sorted(actual_entities) == sorted(expected_entities), (
+            f"Failed for '{raw_text}': "
+            f"expected {expected_entities}, got {actual_entities}"
+        )
+
+
+def test_extract_disease_entities_skips_blank_texts(spark, monkeypatch):
+    """Blank or missing indications should produce empty extractions."""
+    test_data = [
+        ("", []),
+        ("   ", []),
+        (None, []),
+        ("Rare syndrome", ["syndrome"]),
+    ]
+
+    # Track calls with a simple list
+    calls = []
+    
+    def mock_pipeline(text):
+        calls.append(text)
+        responses = {
+            "Rare syndrome": [
+                {"entity_group": "DISEASE", "word": "Syndrome"},
+            ],
+        }
+        return responses.get(text, [])
+
+    monkeypatch.setattr(disease_module, "create_biobert_disease_ner", lambda: mock_pipeline)
+
+    df = spark.createDataFrame([(text,) for text, _ in test_data], ["raw_indication"])
+
+    result_df = disease_module.extract_disease_entities(
+        spark=spark,
+        df=df,
+        input_col="raw_indication",
+        output_col="disease_entities",
+    )
+
+    result_pdf = result_df.toPandas()
+    for i, (raw_text, expected_entities) in enumerate(test_data):
+        actual_entities = result_pdf.iloc[i]["disease_entities"]
+        assert actual_entities == expected_entities, (
+            f"Failed for '{raw_text}': "
+            f"expected {expected_entities}, got {actual_entities}"
+        )
+
+    # Pipeline should only run for non-empty inputs
+    assert calls == ["Rare syndrome"]
+
+
+def test_extract_disease_entities_invalid_column(spark):
+    """Invalid input columns should raise ValueError."""
+    df = spark.createDataFrame(
+        [("Metastatic melanoma treatment",)],
+        ["raw_indication"],
+    )
+
+    with pytest.raises(ValueError, match="Column 'missing' not found"):
+        disease_module.extract_disease_entities(
+            spark=spark,
+            df=df,
+            input_col="missing",
+        )


### PR DESCRIPTION
The input file for the Japanese approvals (context here [#4188](https://github.com/opentargets/issues/issues/4188)) present disease information in a text box that requires extending the NER capabilities of OnToma to diseases/indications.

An example of what I have to extract:
<img width="1478" height="124" alt="image" src="https://github.com/user-attachments/assets/38918a6e-33b1-492d-9b34-f09c0240b32f" />

## What does this PR implement

A NER module to extract clean entity names from raw text labels **before** mapping them to ontology IDs.
- `ner/drug.py`: Entry point to extract drug names from labels in batches.
- `tests/test_ner_disease_extraction.py`: Integration test for the new API.

This PR builds on the work in https://github.com/opentargets/OnToma/pull/35 - PLEASE REVIEW THIS FIRST

## NER Strategy
Much simpler than in the drugs pipeline.
I am using model the result of fine tuning BioBERT with BC5CDR and NCBI diseases corpus, very similarly to the one used for drugs.

Based on the **1066 fragments containing indications**:
- A disease was extracted for 1064 of them
- ... extracting 792 diseases
- ... of which 535 have been mapped to EFO

To inspect results, look at this notebook: https://docs.google.com/spreadsheets/d/1Dxx69kM1tO8KA60yqNViJ6bLCrLjcQzf5uhc-y45Oa8/edit?gid=1067495851#gid=1067495851

## Performance

No batch extraction to simplify the code. Extraction took around 30 seconds, so quite pleased.

The pipeline supports CPU, CUDA, and MPS.
