### PR TITLE
refactor(drug lut): only process drugs with meaningful label information

### DIFF
--- a/src/ontoma/datasource/drug.py
+++ b/src/ontoma/datasource/drug.py
@@ -17,17 +17,17 @@ if TYPE_CHECKING:
 
 
 class OpenTargetsDrug:
-    """Class to extract drug entities from the Open Targets drug index."""
+    """Class to extract drug entities from a dataset following the Open Targets drug index schema."""
 
     @classmethod
     def as_label_lut(
         cls: type[OpenTargetsDrug], 
         drug_index: DataFrame
     ) -> RawEntityLUT:
-        """Generate drug label lookup table from the Open Targets drug index.
+        """Generate drug label lookup table from a dataset following the Open Targets drug index schema.
         
         Args:
-            drug_index (DataFrame): Open Targets drug index.
+            drug_index (DataFrame): Dataset following the Open Targets drug index schema.
 
         Returns:
             RawEntityLUT: Drug label lookup table.
@@ -35,6 +35,12 @@ class OpenTargetsDrug:
         return RawEntityLUT(
             _df=(
                 drug_index
+                # early filter: only process drugs with meaningful label information
+                .filter(
+                    (~f.lower(f.col("name")).startswith("chembl"))
+                    | (f.size(f.col("tradeNames")) > 0)
+                    | (f.size(f.col("synonyms")) > 0)
+                )
                 # filter crossReferences for sources that have labels
                 .withColumn(
                     "crossReferences", 


### PR DESCRIPTION
This PR is within the context of https://github.com/opentargets/issues/issues/4244

We basically need to process the full ChEMBL dataset for drug mapping. This dataset has 2.8M rows even though only 50k have meaningful data. Creating a LUT based on IDs with no label data is inefficient.

The filter keeps rows where:
- name doesn't start with "CHEMBL" (indicating it has a real drug name), OR
- tradeNames array is not null/empty, OR
- synonyms array is not null/empty

**This PR has to be merged before the other NER-related two.**