### PR TITLE
build: pin transformers to version 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "numpy>=2.2.6",
     "rapidfuzz>=3.14.1",
     "torch>=2.8.0",
-    "transformers>=4.57.0",
+    "transformers>=4.57.0,<5.0.0",
     "pyspark==3.5.7",
     "spark-nlp==6.1.5",
     "pandas>=2.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ requires-dist = [
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "spark-nlp", specifier = "==6.1.5" },
     { name = "torch", specifier = ">=2.8.0", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "transformers", specifier = ">=4.57.0" },
+    { name = "transformers", specifier = ">=4.57.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
I had compatibility issues between `transformers 5.x` and `tokenizers 0.22`. Constantly running into:
```
TaskRunError: Couldn't instantiate the backend tokenizer from one of: 
(1) a `tokenizers` library serialization file, 
(2) a slow tokenizer instance to convert or 
(3) an equivalent slow tokenizer class to instantiate and convert.
```

transformers 5 is a major version bump and the BioBERT model I am using is an old model that hasn't been updated to be compatible with it. Downgrading solved the issue