### PR TITLE
chore: bump version to 2.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontoma"
-version = "2.4.0"
+version = "2.4.1"
 description = "Ontology mapping for Open Targets"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "ontoma"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
Bumps the release version `2.4.0` → `2.4.1` (`pyproject.toml` + `uv.lock`).

This release captures the `map_entities` / lookup-table performance work merged since 2.4.0 (PR #51):

- **Deduplicate `(entityLabel, nlpPipelineTrack)` before the NLP pipeline** (`0671191`) — the pipeline is a pure function of that pair, so it now runs once per distinct pair and joins the result back instead of once per row. Big win on inputs with heavy label repetition (literature matches).
- **Drop the `_check_mapping_compatibility` sanity check from `map_entities`** (`e5851b6`) — it scanned the input twice (`distinct().collect()`) on every call; unknown types/kinds now fall through to null `entityIds`, which is the intended behaviour.

(The label-dedup `distinct` salt was added in `4199b1c` and reverted in `9e1ccd7` after the optimized plan showed Catalyst eliminates it — net no-op.)

No API or behaviour changes beyond the above; version bump only.