### PR TITLE
ci: publish to PyPI when a GitHub release is published

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+# Build and upload the package to PyPI whenever a GitHub Release is published.
+# `published` (rather than `created`) also fires when a release is promoted
+# from a draft, which is how releases are cut for this project. Pre-releases
+# trigger this too; switch to `types: [released]` to publish full releases only.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      # The release event checks out the commit the release tag points at,
+      # so the build matches the tagged version exactly.
+      - name: Check out the released commit
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and uploads the package to PyPI automatically whenever a **GitHub Release is published** — replacing the manual `uv build` + `uv publish` step.

## How it works

`.github/workflows/publish-pypi.yml`:
1. Triggers on `release: [published]`.
2. Checks out the commit the release tag points at (so the build matches the tagged version exactly).
3. `uv build` → sdist + wheel.
4. `uv publish` → uploads to PyPI using a token from `secrets.PYPI_API_TOKEN`.

## Required setup (one-time)

Add the PyPI API token as a repository secret named **`PYPI_API_TOKEN`**:
`Settings → Secrets and variables → Actions → New repository secret`.
Use a PyPI token scoped to the `ontoma` project (`pypi-…`).

After this merges and the secret is set, future releases publish automatically — e.g. re-running the `v2.4.1` release, or the next version.

## Notes / options

- **Trigger choice:** `published` (not `created`) so it also fires when a release is promoted from a draft, which is how releases are cut here. It also fires for **pre-releases**; switch to `types: [released]` to publish full releases only.
- **Trusted Publishing alternative:** instead of a token, PyPI's OIDC trusted publishing can be used (add `permissions: id-token: write` and a PyPA publish step, no secret). Happy to switch to that if preferred.
- **Optional hardening:** scope the secret to a dedicated `pypi` GitHub Environment with required reviewers, and/or add a guard that fails if the release tag doesn't match the `pyproject.toml` version.

Note: `2.4.1` is **not yet on PyPI** (latest there is `2.4.0`), so once the secret is configured you can publish it by re-publishing the existing GitHub release.