### PR TITLE
ci: publish to PyPI and create a GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,6 +1,7 @@
 name: Publish to PyPI
 
-# Build and upload the package to PyPI when a version tag is pushed.
+# Publish the package to PyPI and cut a GitHub Release when a version tag is
+# pushed.
 #
 # Triggered by pushing a `v*` tag, e.g.:
 #   git tag v2.4.2 && git push origin v2.4.2
@@ -15,8 +16,9 @@ on:
     tags:
       - 'v*'
 
+# `contents: write` is required for the Create GitHub Release step.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -38,3 +40,12 @@ jobs:
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: uv publish
+
+      # Runs only after a successful PyPI publish, so a failed upload does not
+      # leave a GitHub Release behind. Uses the built-in GITHUB_TOKEN; the
+      # release it creates does not trigger further workflows (this one runs on
+      # tag push, not on release), so there is no loop.
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,19 @@
 name: Publish to PyPI
 
-# Build and upload the package to PyPI whenever a GitHub Release is published.
-# `published` (rather than `created`) also fires when a release is promoted
-# from a draft, which is how releases are cut for this project. Pre-releases
-# trigger this too; switch to `types: [released]` to publish full releases only.
+# Build and upload the package to PyPI when a version tag is pushed.
+#
+# Triggered by pushing a `v*` tag, e.g.:
+#   git tag v2.4.2 && git push origin v2.4.2
+#
+# Tag-push events fire reliably. The `release` event does not: GitHub does not
+# deliver it for a release created on a tag that already existed, which is why
+# release-triggered publishing did not work here. The workflow runs from the
+# tagged commit, so the tag must be cut from a commit that already contains
+# this workflow file (i.e. tag `master` after this is merged).
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -16,9 +23,9 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     steps:
-      # The release event checks out the commit the release tag points at,
-      # so the build matches the tagged version exactly.
-      - name: Check out the released commit
+      # Defaults to github.sha: the commit the pushed tag points at, so the
+      # build matches the tagged version exactly.
+      - name: Check out the tagged commit
         uses: actions/checkout@v4
 
       - name: Install uv


### PR DESCRIPTION
Makes the **Publish to PyPI** workflow trigger on **`push` of a `v*` tag**, and on a successful publish also cut a **GitHub Release** from that tag.

## Why

The `release` event never triggered publishing: GitHub does not deliver a workflow-triggering `release` event for a release created on a tag that already existed on the remote (verified — a `push` test confirmed user workflows do run here, isolating the failure to the `release` event). Tag-push events fire reliably, so the tag push is now the single source of truth: it publishes to PyPI and creates the GitHub Release.

## What the workflow does

```yaml
on:
  push:
    tags:
      - 'v*'
permissions:
  contents: write   # required to create the GitHub Release
```

Steps: checkout the tagged commit → `uv build` → `uv publish` (`secrets.PYPI_API_TOKEN`) → `gh release create "$GITHUB_REF_NAME" --generate-notes`.

- The release step runs **after** a successful PyPI publish, so a failed upload doesn't leave a GitHub Release behind.
- It uses the built-in `GITHUB_TOKEN`. The release it creates does **not** trigger further workflows (this workflow runs on tag push, not on release), so there's no loop or double-publish.
- Removed the old `release` and `workflow_dispatch` triggers.

## How to release after this merges

```bash
git tag v2.4.2 && git push origin v2.4.2   # tag cut from master, which contains this workflow
```

One tag push → PyPI publish + auto-generated GitHub Release. Note the tag must be cut from a commit that already contains this workflow.

To publish the current **2.4.1** (`master` is already at 2.4.1): once merged, `git tag v2.4.1 && git push origin v2.4.1`.