### PR TITLE
feat(drug): {label,source} struct schema + ChEMBL-over-AACT synonym prioritisation

### DIFF
--- a/src/ontoma/datasource/drug.py
+++ b/src/ontoma/datasource/drug.py
@@ -38,15 +38,30 @@ class OpenTargetsDrug:
             _df=(
                 drug_index
                 # the drug index ships tradeNames / synonyms as {label, source}
-                # structs (label = the name, source = provenance e.g. ChEMBL / AACT);
-                # this LUT only needs the label strings, so flatten to array<string>
+                # structs (label = the name, source = provenance e.g. ChEMBL / AACT).
+                # tradeNames are all ChEMBL-sourced; synonyms are split by source so
+                # curated ChEMBL synonyms can be scored above LLM-mined AACT synonyms.
                 .withColumn("tradeNames", f.transform(f.col("tradeNames"), lambda x: x["label"]))
-                .withColumn("synonyms", f.transform(f.col("synonyms"), lambda x: x["label"]))
+                .withColumn(
+                    "synonymsChembl",
+                    f.transform(
+                        f.filter(f.col("synonyms"), lambda s: s["source"] == "ChEMBL"),
+                        lambda s: s["label"]
+                    )
+                )
+                .withColumn(
+                    "synonymsAact",
+                    f.transform(
+                        f.filter(f.col("synonyms"), lambda s: s["source"] == "AACT"),
+                        lambda s: s["label"]
+                    )
+                )
                 # early filter: only process drugs with meaningful label information
                 .filter(
                     (~f.lower(f.col("name")).startswith("chembl"))
                     | (f.size(f.col("tradeNames")) > 0)
-                    | (f.size(f.col("synonyms")) > 0)
+                    | (f.size(f.col("synonymsChembl")) > 0)
+                    | (f.size(f.col("synonymsAact")) > 0)
                 )
                 # extract combination products encoded as "{molecule} component of {product}"
                 # in the trade names and synonyms (e.g. "Ivacaftor component of symkevi"),
@@ -58,7 +73,8 @@ class OpenTargetsDrug:
                             f.transform(
                                 f.concat(
                                     f.coalesce(f.col("tradeNames"), f.array()),
-                                    f.coalesce(f.col("synonyms"), f.array())
+                                    f.coalesce(f.col("synonymsChembl"), f.array()),
+                                    f.coalesce(f.col("synonymsAact"), f.array())
                                 ),
                                 lambda x: extract_combination_product(x)
                             ),
@@ -77,9 +93,16 @@ class OpenTargetsDrug:
                     )
                 )
                 .withColumn(
-                    "synonyms",
+                    "synonymsChembl",
                     f.filter(
-                        f.coalesce(f.col("synonyms"), f.array()),
+                        f.coalesce(f.col("synonymsChembl"), f.array()),
+                        lambda x: ~x.rlike(COMPONENT_OF_PATTERN)
+                    )
+                )
+                .withColumn(
+                    "synonymsAact",
+                    f.filter(
+                        f.coalesce(f.col("synonymsAact"), f.array()),
                         lambda x: ~x.rlike(COMPONENT_OF_PATTERN)
                     )
                 )
@@ -116,14 +139,20 @@ class OpenTargetsDrug:
                     annotate_entity(
                         f.col("tradeNames"), "tbd", 0.999, "trade_name"
                     ).alias("tradeNames"),
+                    # curated ChEMBL synonyms outrank LLM-mined AACT synonyms, which in
+                    # turn outrank crossref-derived labels (LUT keeps the top-score id
+                    # per normalised label, so an AACT-only label still maps)
                     annotate_entity(
-                        f.col("synonyms"), "tbd", 0.999, "synonym"
-                    ).alias("synonyms"),
+                        f.col("synonymsChembl"), "tbd", 0.999, "synonym"
+                    ).alias("synonymsChembl"),
+                    annotate_entity(
+                        f.col("synonymsAact"), "tbd", 0.998, "synonym_aact"
+                    ).alias("synonymsAact"),
                     annotate_entity(
                         f.col("combinationProducts"), "tbd", 0.999, "trade_name_component"
                     ).alias("combinationProducts"),
                     annotate_entity(
-                        f.flatten(f.col("crossReferences")), "tbd", 0.998, "crossref"
+                        f.flatten(f.col("crossReferences")), "tbd", 0.997, "crossref"
                     ).alias("crossReferences")
                 )
                 # flatten and explode array of structs
@@ -134,7 +163,8 @@ class OpenTargetsDrug:
                             f.array(
                                 f.col("name"),
                                 f.col("tradeNames"),
-                                f.col("synonyms"),
+                                f.col("synonymsChembl"),
+                                f.col("synonymsAact"),
                                 f.col("combinationProducts"),
                                 f.col("crossReferences")
                             )

--- a/src/ontoma/datasource/drug.py
+++ b/src/ontoma/datasource/drug.py
@@ -37,6 +37,11 @@ class OpenTargetsDrug:
         return RawEntityLUT(
             _df=(
                 drug_index
+                # the drug index ships tradeNames / synonyms as {label, source}
+                # structs (label = the name, source = provenance e.g. ChEMBL / AACT);
+                # this LUT only needs the label strings, so flatten to array<string>
+                .withColumn("tradeNames", f.transform(f.col("tradeNames"), lambda x: x["label"]))
+                .withColumn("synonyms", f.transform(f.col("synonyms"), lambda x: x["label"]))
                 # early filter: only process drugs with meaningful label information
                 .filter(
                     (~f.lower(f.col("name")).startswith("chembl"))

--- a/src/ontoma/datasource/drug.py
+++ b/src/ontoma/datasource/drug.py
@@ -43,14 +43,14 @@ class OpenTargetsDrug:
                 # curated ChEMBL synonyms can be scored above LLM-mined AACT synonyms.
                 .withColumn("tradeNames", f.transform(f.col("tradeNames"), lambda x: x["label"]))
                 .withColumn(
-                    "synonymsChembl",
+                    "synonymsCurated",
                     f.transform(
                         f.filter(f.col("synonyms"), lambda s: s["source"] == "ChEMBL"),
                         lambda s: s["label"]
                     )
                 )
                 .withColumn(
-                    "synonymsAact",
+                    "synonymsInferred",
                     f.transform(
                         f.filter(f.col("synonyms"), lambda s: s["source"] == "AACT"),
                         lambda s: s["label"]
@@ -60,8 +60,8 @@ class OpenTargetsDrug:
                 .filter(
                     (~f.lower(f.col("name")).startswith("chembl"))
                     | (f.size(f.col("tradeNames")) > 0)
-                    | (f.size(f.col("synonymsChembl")) > 0)
-                    | (f.size(f.col("synonymsAact")) > 0)
+                    | (f.size(f.col("synonymsCurated")) > 0)
+                    | (f.size(f.col("synonymsInferred")) > 0)
                 )
                 # extract combination products encoded as "{molecule} component of {product}"
                 # in the trade names and synonyms (e.g. "Ivacaftor component of symkevi"),
@@ -73,8 +73,8 @@ class OpenTargetsDrug:
                             f.transform(
                                 f.concat(
                                     f.coalesce(f.col("tradeNames"), f.array()),
-                                    f.coalesce(f.col("synonymsChembl"), f.array()),
-                                    f.coalesce(f.col("synonymsAact"), f.array())
+                                    f.coalesce(f.col("synonymsCurated"), f.array()),
+                                    f.coalesce(f.col("synonymsInferred"), f.array())
                                 ),
                                 lambda x: extract_combination_product(x)
                             ),
@@ -93,16 +93,16 @@ class OpenTargetsDrug:
                     )
                 )
                 .withColumn(
-                    "synonymsChembl",
+                    "synonymsCurated",
                     f.filter(
-                        f.coalesce(f.col("synonymsChembl"), f.array()),
+                        f.coalesce(f.col("synonymsCurated"), f.array()),
                         lambda x: ~x.rlike(COMPONENT_OF_PATTERN)
                     )
                 )
                 .withColumn(
-                    "synonymsAact",
+                    "synonymsInferred",
                     f.filter(
-                        f.coalesce(f.col("synonymsAact"), f.array()),
+                        f.coalesce(f.col("synonymsInferred"), f.array()),
                         lambda x: ~x.rlike(COMPONENT_OF_PATTERN)
                     )
                 )
@@ -143,11 +143,11 @@ class OpenTargetsDrug:
                     # turn outrank crossref-derived labels (LUT keeps the top-score id
                     # per normalised label, so an AACT-only label still maps)
                     annotate_entity(
-                        f.col("synonymsChembl"), "tbd", 0.999, "synonym"
-                    ).alias("synonymsChembl"),
+                        f.col("synonymsCurated"), "tbd", 0.999, "synonym"
+                    ).alias("synonymsCurated"),
                     annotate_entity(
-                        f.col("synonymsAact"), "tbd", 0.998, "synonym_aact"
-                    ).alias("synonymsAact"),
+                        f.col("synonymsInferred"), "tbd", 0.998, "synonym_aact"
+                    ).alias("synonymsInferred"),
                     annotate_entity(
                         f.col("combinationProducts"), "tbd", 0.999, "trade_name_component"
                     ).alias("combinationProducts"),
@@ -163,8 +163,8 @@ class OpenTargetsDrug:
                             f.array(
                                 f.col("name"),
                                 f.col("tradeNames"),
-                                f.col("synonymsChembl"),
-                                f.col("synonymsAact"),
+                                f.col("synonymsCurated"),
+                                f.col("synonymsInferred"),
                                 f.col("combinationProducts"),
                                 f.col("crossReferences")
                             )

--- a/tests/test_datasource_drug.py
+++ b/tests/test_datasource_drug.py
@@ -55,13 +55,15 @@ def drug_label_rows(spark):
     tradeNames / synonyms follow the {label, source} struct schema.
     """
     data = [
-        # Ivacaftor: combination product (symkevi) + plain trade name (Kalydeco)
+        # Ivacaftor: combination product (symkevi) + plain trade name (Kalydeco),
+        # a curated ChEMBL synonym (VX-770) + a mined AACT synonym (ivx-mined),
+        # and a DailyMed crossref label (to exercise the score tiers)
         (
             "CHEMBL2010601",
             "IVACAFTOR",
             _ls("Ivacaftor component of symkevi", "Kalydeco"),
-            _ls("Ivacaftor", "VX-770"),
-            [],
+            _ls("Ivacaftor", "VX-770") + [("ivx-mined", "AACT")],
+            [("DailyMed", ["ivacaftor-dm"])],
         ),
         # Tezacaftor: the other component of the same combination product
         (
@@ -176,3 +178,26 @@ def test_product_shared_across_fields_is_deduplicated(drug_label_rows):
         if r["entityId"] == "CHEMBLDUP" and r["entityLabel"] == "dupprod"
     ]
     assert len(rows) == 1
+
+
+def test_synonym_score_tiers_by_source(drug_label_rows):
+    """ChEMBL synonyms (0.999) outrank AACT synonyms (0.998), which outrank crossrefs (0.997)."""
+    chembl_syn = [r for r in drug_label_rows if r["entitySource"] == "synonym"]
+    aact_syn = [r for r in drug_label_rows if r["entitySource"] == "synonym_aact"]
+    crossref = [r for r in drug_label_rows if r["entitySource"] == "crossref"]
+
+    assert chembl_syn and aact_syn and crossref
+    assert all(r["entityScore"] == 0.999 for r in chembl_syn)
+    assert all(r["entityScore"] == 0.998 for r in aact_syn)
+    assert all(r["entityScore"] == 0.997 for r in crossref)
+
+
+def test_aact_synonym_label_present_with_source(drug_label_rows):
+    """The mined AACT synonym maps to its molecule, tagged with the AACT source."""
+    rows = [
+        r
+        for r in drug_label_rows
+        if r["entityId"] == "CHEMBL2010601" and r["entityLabel"] == "ivx-mined"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["entitySource"] == "synonym_aact"

--- a/tests/test_datasource_drug.py
+++ b/tests/test_datasource_drug.py
@@ -11,12 +11,21 @@ from pyspark.sql.types import (
 from ontoma.datasource.drug import OpenTargetsDrug
 
 
+_LABEL_SOURCE = ArrayType(
+    StructType(
+        [
+            StructField("label", StringType()),
+            StructField("source", StringType()),
+        ]
+    )
+)
+
 DRUG_INDEX_SCHEMA = StructType(
     [
         StructField("id", StringType()),
         StructField("name", StringType()),
-        StructField("tradeNames", ArrayType(StringType())),
-        StructField("synonyms", ArrayType(StringType())),
+        StructField("tradeNames", _LABEL_SOURCE),
+        StructField("synonyms", _LABEL_SOURCE),
         StructField(
             "crossReferences",
             ArrayType(
@@ -32,27 +41,33 @@ DRUG_INDEX_SCHEMA = StructType(
 )
 
 
+def _ls(*names):
+    """Build a [{label, source}] struct list (all ChEMBL-sourced) for fixtures."""
+    return [(n, "ChEMBL") for n in names]
+
+
 @pytest.fixture(scope="module")
 def drug_label_rows(spark):
     """Collected label-LUT rows from a small in-memory drug index.
 
     Covers a combination product shared by two molecules (Symkevi =
     Ivacaftor + Tezacaftor), a plain trade name, and a noisy product name.
+    tradeNames / synonyms follow the {label, source} struct schema.
     """
     data = [
         # Ivacaftor: combination product (symkevi) + plain trade name (Kalydeco)
         (
             "CHEMBL2010601",
             "IVACAFTOR",
-            ["Ivacaftor component of symkevi", "Kalydeco"],
-            ["Ivacaftor", "VX-770"],
+            _ls("Ivacaftor component of symkevi", "Kalydeco"),
+            _ls("Ivacaftor", "VX-770"),
             [],
         ),
         # Tezacaftor: the other component of the same combination product
         (
             "CHEMBL3544914",
             "TEZACAFTOR",
-            ["Tezacaftor component of symkevi"],
+            _ls("Tezacaftor component of symkevi"),
             [],
             [],
         ),
@@ -60,7 +75,7 @@ def drug_label_rows(spark):
         (
             "CHEMBLNOISE",
             "SOMEDRUG",
-            ["Somedrug component of /weirdname"],
+            _ls("Somedrug component of /weirdname"),
             [],
             [],
         ),
@@ -69,15 +84,15 @@ def drug_label_rows(spark):
             "CHEMBLUPPER",
             "MODAFINIL",
             [],
-            ["MODAFINIL COMPONENT OF THN102"],
+            _ls("MODAFINIL COMPONENT OF THN102"),
             [],
         ),
         # Same product encoded in both tradeNames and synonyms -> deduped
         (
             "CHEMBLDUP",
             "SOMEDRUGTWO",
-            ["Somedrugtwo component of dupprod"],
-            ["Somedrugtwo component of dupprod"],
+            _ls("Somedrugtwo component of dupprod"),
+            _ls("Somedrugtwo component of dupprod"),
             [],
         ),
     ]


### PR DESCRIPTION
## Summary

The Open Targets drug index changes `tradeNames` and `synonyms` from `array<string>` to `array<struct<label, source>>` (each name now carries provenance — `ChEMBL`, plus a new clinical-trial `AACT` source). This updates OnToma's drug datasource to read the new schema.

- `OpenTargetsDrug.as_label_lut` now flattens `tradeNames`/`synonyms` to their `label` strings up front, so the combination-product extraction (`X component of Y`), the `component of` filtering, and `annotate_entity` operate on `array<string>` exactly as before.
- `as_id_lut` only consumes `crossReferences` (unchanged) and is unaffected.
- **The drug label LUT now also picks up the new AACT-sourced synonyms** (extra trial-name → ChEMBL-id coverage).
- Drug datasource test fixtures updated to the `{label, source}` struct schema.

## Source-based prioritisation

Curated ChEMBL synonyms should outrank the LLM-mined AACT synonyms. The LUT already keeps the top-`entityScore` id per normalised label (`dense_rank` over `entityScore desc`, keep rank 1), so this is just a scoring change. New tiers:

```
name 1.0  >  tradeName / ChEMBL synonym / combination 0.999  >  AACT synonym 0.998  >  crossref 0.997
```

- `as_label_lut` splits synonyms by source: ChEMBL synonyms keep `0.999` (`synonym`), AACT synonyms get `0.998` (`synonym_aact`).
- Crossref labels downgraded `0.998 → 0.997` so they sit below AACT synonyms.
- A label that is **only** an AACT synonym is still the max for that label, so it still maps — this only changes **cross-molecule conflicts**, where ChEMBL now wins.

## Context

Downstream of the schema change in opentargets/pts#142 (tracking issue opentargets/issues#4414). OnToma and the drug-index output move together per release, so this expects the new struct schema (no string fallback).

## Test plan

- [x] `pytest tests/test_datasource_drug.py` — 9 passed (struct fixtures + score-tier tests)
- [ ] NER tests not run (optional `[ner]` extra / `torch` not installed locally); unaffected by this change
