### PR TITLE
chore: bump version to 2.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ontoma"
-version = "2.5.0"
+version = "2.5.1"
 description = "Ontology mapping for Open Targets"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
Bump `pyproject.toml` version 2.5.0 → 2.5.1 to cut the **v2.5.1** release.

Releases the changes merged to `master` since v2.5.0 (notably `fix(drug): process all query drugs as symbols`).

After this merges, pushing the `v2.5.1` tag triggers `publish-pypi.yml` to build + publish to PyPI and create the GitHub Release. The bump is required first so the built package version matches the tag (otherwise `uv publish` would rebuild 2.5.0 and be rejected by PyPI).